### PR TITLE
Update binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,7 @@
             "include_dirs": [
                 "src",
                 "src/contrib/epee/include",
+                "/usr/local/opt/boost/include",
                 "<!(node -e \"require('nan')\")",
             ],
             "link_settings": {


### PR DESCRIPTION
I'm trying to install this on macOS and it looks like this is the only way for `gyp` to find Boost library and build/install everything properly. I tried setting environmental variables, installing/linking different Boost versions but literally nothing did the trick as adding this single line... Let me know if you have some idea, I can try it out and maybe get lucky ^^