### PR TITLE
Bound RTM Base58/Bech32 address input lengths to mitigate DoS

### DIFF
--- a/rtm.js
+++ b/rtm.js
@@ -387,7 +387,12 @@ function sha256(buffer) {
   return crypto.createHash('sha256').update(buffer).digest();
 }
 
+const MAX_BASE58_ADDRESS_LENGTH = 128;
+const MAX_BECH32_ADDRESS_LENGTH = 128;
+
 function decodeBase58Check(value) {
+  if (value.length > MAX_BASE58_ADDRESS_LENGTH) throw new Error('Base58 address too long');
+
   let num = 0n;
   for (const char of value) {
     const index = BASE58_INDEXES.get(char);
@@ -412,6 +417,7 @@ function decodeBase58Check(value) {
 }
 
 function addressToScript(addr) {
+  if (addr.length > MAX_BECH32_ADDRESS_LENGTH) throw new Error('Invalid address ' + addr);
   let decoded;
   try {
     decoded = decodeBase58Check(addr);


### PR DESCRIPTION
### Motivation
- Prevent untrusted daemon-supplied RTM payee addresses from triggering unbounded BigInt work, large buffer allocations, or event-loop/blocking by rejecting overlong inputs before decoding.

### Description
- Add `MAX_BASE58_ADDRESS_LENGTH` and `MAX_BECH32_ADDRESS_LENGTH` constants and an early length check in `decodeBase58Check` to reject excessively long Base58 inputs before performing BigInt arithmetic.
- Add an early length check in `addressToScript` to reject overlong addresses before attempting Base58 or Bech32 decoding, leaving valid address handling unchanged.

### Testing
- Inspected the `rtm.js` diff to confirm only minimal length checks were added around `decodeBase58Check` and `addressToScript`, and no other logic was changed.
- Attempted to load `rtm.js` with Node (`require('./rtm.js')`) but runtime execution could not be completed in this environment because the `bech32` dependency is not installed, so full dynamic tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15fbbddb9083218e23b40753990614)