### PR TITLE
Harden Forknote2 blockchain_branch depth parsing to prevent allocation DoS

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -1198,6 +1198,9 @@ namespace cryptonote
         tx_extra_merge_mining_tag mm_tag;
         if (!get_mm_tag_from_extra(b.miner_tx.extra, mm_tag))
           return false;
+        static constexpr size_t MAX_BYTECOIN_BLOCKCHAIN_BRANCH_DEPTH = 64;
+        if (mm_tag.depth > MAX_BYTECOIN_BLOCKCHAIN_BRANCH_DEPTH)
+          return false;
 
         ar.tag("blockchain_branch");
         ar.begin_array();


### PR DESCRIPTION
### Motivation
- The Forknote2/Bytecoin parent-block deserializer used the untrusted `tx_extra_merge_mining_tag.depth` directly to size `bytecoin_block.blockchain_branch`, enabling a malicious block blob to force an enormous allocation and crash the process.

### Description
- Add a hard upper bound `static constexpr size_t MAX_BYTECOIN_BLOCKCHAIN_BRANCH_DEPTH = 64` and return `false` when `mm_tag.depth` exceeds this value before calling `PREPARE_CUSTOM_VECTOR_SERIALIZATION` in the `blockchain_branch` deserialization path in `src/cryptonote_basic/cryptonote_basic.h`.

### Testing
- Ran `npm test` locally, but the run could not complete due to network/npm registry access restrictions (HTTP 403 while fetching dependency `bech32`), so the automated test suite did not finish successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a160f70f07c832195eb4b1a4c099f02)