### PR TITLE
Clamp Forknote2 merge-mining depth during deserialize

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -1199,6 +1199,10 @@ namespace cryptonote
         if (!get_mm_tag_from_extra(b.miner_tx.extra, mm_tag))
           return false;
 
+        static const size_t MAX_MERGE_MINING_DEPTH = 128;
+        if (mm_tag.depth > MAX_MERGE_MINING_DEPTH)
+          return false;
+
         ar.tag("blockchain_branch");
         ar.begin_array();
         PREPARE_CUSTOM_VECTOR_SERIALIZATION(mm_tag.depth, const_cast<bytecoin_block&>(b).blockchain_branch);


### PR DESCRIPTION
### Motivation
- Prevent untrusted `tx_extra_merge_mining_tag.depth` from causing unbounded `std::vector` allocation during Forknote2 parent-block deserialization, which can be triggered by daemon-controlled block templates and lead to OOM/abort.

### Description
- Add a defensive check in `src/cryptonote_basic/cryptonote_basic.h` that returns `false` if `mm_tag.depth` exceeds `MAX_MERGE_MINING_DEPTH` (set to `128`) before calling `PREPARE_CUSTOM_VECTOR_SERIALIZATION(mm_tag.depth, ...)`, rejecting malformed inputs early.

### Testing
- No automated build or unit test suite was run in this environment; the patch was applied and committed successfully (`git commit` completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a160e2e1280832192b330b2971c509e)