### PR TITLE
Harden legacy RingCT prunable deserialization against oversized output counts

### DIFF
--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -69,6 +69,8 @@ extern "C" {
 
 //Namespace specifically for ring ct code
 namespace rct {
+    static constexpr size_t MAX_LEGACY_RINGCT_OUTPUTS = 1024;
+
     //basic ops containers
     typedef unsigned char * Bytes;
 
@@ -526,7 +528,7 @@ namespace rct {
             return ar.stream().good();
 	  if (type != RCTTypeFull && type != RCTTypeSimple && type != RCTTypeBulletproof && type != RCTTypeBulletproof2 && type != RCTTypeCLSAG && type != RCTTypeBulletproofPlus && type != RCTTypeFullProofs && type != RCTTypeSalviumZero && type != RCTTypeSalviumOne)
             return false;
-	  if (type == RCTTypeBulletproofPlus || type == RCTTypeFullProofs || type == RCTTypeSalviumZero || type == RCTTypeSalviumOne)
+          if (type == RCTTypeBulletproofPlus || type == RCTTypeFullProofs || type == RCTTypeSalviumZero || type == RCTTypeSalviumOne)
           {
             uint32_t nbp = bulletproofs_plus.size();
             VARINT_FIELD(nbp)
@@ -569,6 +571,8 @@ namespace rct {
           }
           else
           {
+            if (outputs > MAX_LEGACY_RINGCT_OUTPUTS)
+              return false;
             ar.tag("rangeSigs");
             ar.begin_array();
             PREPARE_CUSTOM_VECTOR_SERIALIZATION(outputs, rangeSigs);


### PR DESCRIPTION
### Motivation
- The RingCT prunable deserializer can call `vec.resize(outputs)` using an attacker-controlled `outputs` count obtained from a parsed transaction prefix, enabling large allocations and OOM when parsing untrusted block blobs.
- Rather than changing transaction-version acceptance, the change hardens the reachable deserialization path to reject unreasonable legacy RingCT output counts before any vector resizing occurs.

### Description
- Add a constant `MAX_LEGACY_RINGCT_OUTPUTS = 1024` in `rct` namespace to bound legacy (non-bulletproof) RingCT outputs.
- Insert an early check `if (outputs > MAX_LEGACY_RINGCT_OUTPUTS) return false;` in `rctSigPrunable::serialize_rctsig_prunable` before `PREPARE_CUSTOM_VECTOR_SERIALIZATION(outputs, rangeSigs);` to prevent oversized `rangeSigs` allocations.
- Keep existing behavior for bulletproof, bulletproof+, and other RingCT paths unchanged.

### Testing
- Attempted to run the repository test suite with `npm test`, but it failed due to external registry access returning `403 Forbidden` for `https://registry.npmjs.org/bech32`, so automated tests could not be completed in this environment.
- No unit test failures attributable to the change were observed locally because the test run could not proceed to completion due to the registry error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a160f2337948321bd1848f593be2d34)