### PR TITLE
Reject oversized tx_hash lists in construct_block_blob to mitigate DoS

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -46,6 +46,7 @@ inline void SetExport(Isolate* isolate, Local<Object> target, const char* name,
 
 // cryptonote::append_mm_tag_to_extra writes byte with TX_EXTRA_MERGE_MINING_TAG (1 here) and VARINT DEPTH (2 here)
 const size_t MM_NONCE_SIZE = 1 + 2 + sizeof(crypto::hash);
+const size_t MAX_TX_HASHES_FOR_PARENT_BLOCK = 16384;
 
 blobdata uint64be_to_blob(uint64_t num) {
     blobdata res = "        ";
@@ -238,6 +239,7 @@ void construct_block_blob(const FunctionCallbackInfo<Value>& info) { // (parentB
 
     b.nonce = nonce;
     if (blob_type == BLOB_TYPE_FORKNOTE2) {
+        if (b.tx_hashes.size() > MAX_TX_HASHES_FOR_PARENT_BLOCK) return ThrowError(isolate, "Block template has too many transaction hashes.");
         block parent_block;
         b.parent_block.nonce = nonce;
         if (!construct_parent_block(b, parent_block)) return ThrowError(isolate, "Failed to construct parent block");


### PR DESCRIPTION
### Motivation
- Prevent a remote daemon from triggering unbounded stack allocation in the merkle `tree_hash` path by rejecting overly large merged-mining templates before `construct_parent_block` is invoked. 

### Description
- Add a conservative hard limit `MAX_TX_HASHES_FOR_PARENT_BLOCK = 16384` to limit how many `tx_hashes` are accepted for `BLOB_TYPE_FORKNOTE2`. 
- Validate `b.tx_hashes.size()` in `construct_block_blob` and return an error if the template exceeds the limit, avoiding the downstream call chain that leads to stack `alloca` in `tree_hash`.

### Testing
- Ran the package test command `npm test`, which failed in this environment due to a network/registry `403 Forbidden` error when fetching dependencies (specifically `bech32`), so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16118cedc48321b3a54c1ea859bbf3)