### PR TITLE
Bounds-check mm_tag.depth before allocating parent `blockchain_branch` for v2/v3 blocks

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -1201,6 +1201,8 @@ namespace cryptonote
 
         ar.tag("blockchain_branch");
         ar.begin_array();
+        if (!typename Archive<W>::is_saving() && mm_tag.depth > ar.remaining_bytes() / sizeof(crypto::hash))
+          return false;
         PREPARE_CUSTOM_VECTOR_SERIALIZATION(mm_tag.depth, const_cast<bytecoin_block&>(b).blockchain_branch);
         if (mm_tag.depth != b.blockchain_branch.size())
           return false;


### PR DESCRIPTION
### Motivation
- Parsing of `parent_block` for `BLOCK_MAJOR_VERSION_2`/`BLOCK_MAJOR_VERSION_3` made an untrusted `tx_extra` merge-mining `depth` reachable from callers and it was used to resize `blockchain_branch` without bounds, allowing OOM or exception aborts. 
- The goal is to prevent attacker-controlled large `mm_tag.depth` from driving an unchecked `std::vector::resize` while preserving valid deserialization behavior. 

### Description
- Add a deserialization-time guard in `src/cryptonote_basic/cryptonote_basic.h` that checks `mm_tag.depth` against `ar.remaining_bytes() / sizeof(crypto::hash)` before calling `PREPARE_CUSTOM_VECTOR_SERIALIZATION`. 
- The check is only applied on load (`!typename Archive<W>::is_saving()`) and returns `false` for inputs that claim more branch entries than remain in the serialized stream. 
- This prevents an attacker from causing a huge allocation for `b.blockchain_branch` when the claimed depth cannot be satisfied by the input bytes. 

### Testing
- Ran `npm test` in this environment, which failed before running tests due to dependency fetch error (`403 Forbidden - GET https://registry.npmjs.org/bech32`) so test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16118be0808321a41cc7e91c548126)