### PR TITLE
Limit get_block_id transaction hash count to prevent stack overflow

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -46,6 +46,7 @@ inline void SetExport(Isolate* isolate, Local<Object> target, const char* name,
 
 // cryptonote::append_mm_tag_to_extra writes byte with TX_EXTRA_MERGE_MINING_TAG (1 here) and VARINT DEPTH (2 here)
 const size_t MM_NONCE_SIZE = 1 + 2 + sizeof(crypto::hash);
+const size_t MAX_BLOCK_ID_TX_HASHES = 65535;
 
 blobdata uint64be_to_blob(uint64_t num) {
     blobdata res = "        ";
@@ -203,6 +204,7 @@ void get_block_id(const FunctionCallbackInfo<Value>& info) {
     block b = AUTO_VAL_INIT(b);
     b.set_blob_type(blob_type);
     if (!parse_and_validate_block_from_blob(input, b)) return ThrowError(isolate, "Failed to parse block");
+    if (b.tx_hashes.size() > MAX_BLOCK_ID_TX_HASHES) return ThrowError(isolate, "Block has too many transaction hashes");
 
     crypto::hash block_id;
     if (!get_block_hash(b, block_id)) return ThrowError(isolate, "Failed to calculate hash for block");


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service crash caused by parsing untrusted block blobs with an excessive number of `tx_hashes`, since `get_block_id` reaches Merkle tree hashing that uses stack-allocation in `tree_hash`.

### Description
- Add a defensive cap `MAX_BLOCK_ID_TX_HASHES = 65535` in `src/main.cc` and return an error when `b.tx_hashes.size()` exceeds this limit before calling `get_block_hash`, preserving normal behavior for typical blocks.

### Testing
- Ran `npm test` in the environment, which failed due to a network/npm registry `403 Forbidden` error fetching the `bech32` dependency so no project tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16118222808321ae62e69c104c1e8e)