### PR TITLE
Bound untrusted block tx_hashes before merkle hashing

### DIFF
--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -15,6 +15,11 @@ using namespace epee;
 
 namespace cryptonote
 {
+  namespace
+  {
+    // Keep merkle tree hashing scratch allocations bounded in tree_hash().
+    const size_t MAX_BLOCK_TX_HASHES = 0x10000;
+  }
   //---------------------------------------------------------------
   void get_transaction_prefix_hash(const transaction_prefix& tx, crypto::hash& h)
   {
@@ -276,6 +281,9 @@ namespace cryptonote
   //---------------------------------------------------------------
   bool get_block_hashing_blob(const block& b, blobdata& blob)
   {
+    if (b.tx_hashes.size() > MAX_BLOCK_TX_HASHES)
+      return false;
+
     if (b.blob_type == BLOB_TYPE_CRYPTONOTE_XTNC || b.blob_type == BLOB_TYPE_CRYPTONOTE_CUCKOO || b.blob_type == BLOB_TYPE_CRYPTONOTE_TUBE || b.blob_type == BLOB_TYPE_CRYPTONOTE_XTA) {
       blob = t_serializable_object_to_blob(b.major_version);
       blob.append(reinterpret_cast<const char*>(&b.minor_version), sizeof(b.minor_version));


### PR DESCRIPTION
### Motivation
- Prevent untrusted/remote block templates from triggering unbounded merkle-tree scratch allocations (via `tree_hash`) that can exhaust the process stack and cause a denial-of-service.

### Description
- Introduce `MAX_BLOCK_TX_HASHES` and return `false` from `get_block_hashing_blob` when `b.tx_hashes.size()` exceeds this limit to stop large attacker-controlled inputs from reaching `tree_hash`.

### Testing
- Ran the project test command `npm test`, which failed in this environment due to registry access (`403 Forbidden` fetching dependency `bech32`), so automated tests could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1611d3a0848321971bbdf6a2dcfded)