### PR TITLE
Guard Forknote parent blockchain branch depth

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -1132,6 +1132,18 @@ namespace cryptonote
     std::vector<crypto::hash> blockchain_branch;
   };
 
+  template <typename Archive>
+  bool has_enough_blockchain_branch_bytes(Archive&, size_t, const boost::mpl::bool_<true>& /*is_saving*/)
+  {
+    return true;
+  }
+
+  template <typename Archive>
+  bool has_enough_blockchain_branch_bytes(Archive& ar, size_t depth, const boost::mpl::bool_<false>& /*is_saving*/)
+  {
+    return depth <= ar.remaining_bytes() / sizeof(crypto::hash);
+  }
+
   struct serializable_bytecoin_block
   {
     bytecoin_block& b;
@@ -1201,6 +1213,8 @@ namespace cryptonote
 
         ar.tag("blockchain_branch");
         ar.begin_array();
+        if (!has_enough_blockchain_branch_bytes(ar, mm_tag.depth, typename Archive<W>::is_saving()))
+          return false;
         PREPARE_CUSTOM_VECTOR_SERIALIZATION(mm_tag.depth, const_cast<bytecoin_block&>(b).blockchain_branch);
         if (mm_tag.depth != b.blockchain_branch.size())
           return false;


### PR DESCRIPTION
### Motivation
- Prevent an attacker-controlled merge-mining `depth` (read from `tx_extra` as an untrusted varint) from driving an unchecked `std::vector::resize` during deserialization which can OOM or abort the process. 
- The unsafe path is reachable because parent block parsing for v2/v3 blocks deserializes a merge-mining tag and uses its `depth` directly to size the `blockchain_branch` vector. 
- Ensure deserialization validates the claimed depth against the remaining input before any allocation occurs.

### Description
- Add load/save-aware helper templates `has_enough_blockchain_branch_bytes(Archive&, size_t, ...)` that return `true` for saving and perform a remaining-bytes check for loading. 
- Invoke the load-side check immediately before `PREPARE_CUSTOM_VECTOR_SERIALIZATION(mm_tag.depth, ...)` so deserialization returns `false` when `mm_tag.depth` claims more `crypto::hash` entries than remain. 
- Change implemented in `src/cryptonote_basic/cryptonote_basic.h` (helper templates + early validation before resizing `blockchain_branch`).

### Testing
- Ran `git diff --check` which completed successfully and showed no whitespace/style issues. 
- Attempted `npm install --no-audit --no-fund --no-package-lock` to build the native addon and run tests, but the run was blocked by the npm registry returning `403 Forbidden`, so the native build/tests could not be executed in this environment. 
- Attempted a C++ syntax-only check with `g++ -std=c++17 -I src -I src/contrib/epee/include -fsyntax-only src/cryptonote_basic/cryptonote_format_utils.cpp`, but local compilation was prevented by missing Boost headers and restricted `apt-get` access in the runner environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19ce6f7ddc8321b4ee2d81b545448b)