### PR TITLE
Fix merged-mining parent timestamp trust boundary

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -120,9 +120,6 @@ static bool fillExtraMM(cryptonote::block& block1, const cryptonote::block& bloc
     std::copy(extra_nonce_replace.begin(), extra_nonce_replace.end(), extra.begin() + pos + 1 + new_extra_nonce_size + 1);
     //extra.resize(pos + 1 + extra_nonce_size + 1);
 
-    // get the most recent timestamp (solve duplicated timestamps on child coin)
-    if (block2.timestamp > block1.timestamp) block1.timestamp = block2.timestamp;
-
     return true;
 }
 


### PR DESCRIPTION
### Motivation
- The merged-mining path allowed an untrusted child block template to overwrite the parent block header timestamp, which can produce consensus-invalid parent jobs and waste miner hashrate.

### Description
- Remove the child-controlled timestamp overwrite in `fillExtraMM` so the parent template's consensus-relevant `timestamp` is no longer mutated by the child template while leaving the merged-mining extra-tag insertion intact.

### Testing
- Inspected `src/main.cc` before and after the change and validated the offending lines were removed with `sed`/`nl` and `git diff`, and committed the change, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16083445b88321935e65499f6656b4)