### PR TITLE
Fix OOB write in fillExtraMM nonce handling

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -108,16 +108,22 @@ static bool fillExtraMM(cryptonote::block& block1, const cryptonote::block& bloc
         return false;
     }
 
-    const int extra_nonce_size = extra[pos + 1];
-    const int new_extra_nonce_size = extra_nonce_size - MM_NONCE_SIZE;
+    const size_t extra_nonce_size = extra[pos + 1];
+    const size_t extra_nonce_start = pos + 2;
+    if (extra_nonce_start > extra.size() || extra_nonce_start + extra_nonce_size > extra.size()) {
+        fprintf(stderr, "Malformed TX_EXTRA_NONCE length in extra\n");
+        return false;
+    }
 
-    if (new_extra_nonce_size < 0) {
+    if (extra_nonce_size < MM_NONCE_SIZE) {
         fprintf(stderr, "Too small extra size, can't fit MM tag here\n");
         return false;
     }
 
-    extra[pos + 1] = new_extra_nonce_size;
-    std::copy(extra_nonce_replace.begin(), extra_nonce_replace.end(), extra.begin() + pos + 1 + new_extra_nonce_size + 1);
+    const size_t new_extra_nonce_size = extra_nonce_size - MM_NONCE_SIZE;
+
+    extra[pos + 1] = static_cast<uint8_t>(new_extra_nonce_size);
+    std::copy(extra_nonce_replace.begin(), extra_nonce_replace.end(), extra.begin() + extra_nonce_start + new_extra_nonce_size);
     //extra.resize(pos + 1 + extra_nonce_size + 1);
 
     // get the most recent timestamp (solve duplicated timestamps on child coin)


### PR DESCRIPTION
### Motivation

- The `fillExtraMM` code trusted the `TX_EXTRA_NONCE` declared length byte and copied a 35-byte merged-mining tag without verifying the actual payload was present, leading to an out-of-bounds write and possible native heap corruption. 
- The change aims to validate the nonce payload length before any rewrite/copy to prevent daemon-supplied malformed block templates from crashing or corrupting the process.

### Description

- Add explicit bounds validation that `extra_nonce_start` and `extra_nonce_start + extra_nonce_size` are within `miner_tx.extra` before modifying the vector. 
- Validate that the declared `extra_nonce_size` is at least `MM_NONCE_SIZE` and compute `new_extra_nonce_size` as an unsigned `size_t`. 
- Update the nonce-length byte with a safe `static_cast<uint8_t>` and copy the merged-mining tag to a destination offset derived from the validated `extra_nonce_start` and `new_extra_nonce_size`, preserving original behavior for valid inputs.

### Testing

- Reviewed the source patch and diff to confirm the added checks and adjusted offsets are correct. 
- Displayed the modified region with `nl -ba src/main.cc | sed -n '96,135p'` to verify the new logic in context. 
- No project build or automated test suite was run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1609f3d97c83218931c3f703f28d8c)