### PR TITLE
Reject invalid RTM coinbase dev rewards

### DIFF
--- a/rtm.js
+++ b/rtm.js
@@ -459,12 +459,18 @@ function validateCoinbaseDevReward(coinbaseDevReward, rewardToPool) {
   return true;
 }
 
-function generateTransactionOutputs(rpcData, poolAddress) {
-  let reward       = rpcData.coinbasevalue + (rpcData.coinbasedevreward ? rpcData.coinbasedevreward.value : 0);
+function hasValidCoinbaseDevReward(rpcData) {
+  if (rpcData.coinbasedevreward === undefined || rpcData.coinbasedevreward === null) return false;
+  if (!validateCoinbaseDevReward(rpcData.coinbasedevreward, rpcData.coinbasevalue)) throw new Error('Invalid coinbase dev reward');
+  return true;
+}
+
+function generateTransactionOutputs(rpcData, poolAddress, hasDevReward) {
+  let reward       = rpcData.coinbasevalue + (hasDevReward ? rpcData.coinbasedevreward.value : 0);
   let rewardToPool = reward;
   let txOutputBuffers = [];
 
-  if (validateCoinbaseDevReward(rpcData.coinbasedevreward, rewardToPool)) {
+  if (hasDevReward) {
     const rewards = createTransactionOutput(rpcData.coinbasedevreward.value, null, rewardToPool, reward, txOutputBuffers, Buffer.from(rpcData.coinbasedevreward.scriptpubkey, 'hex'));
     reward        = rewards.reward;
     rewardToPool  = rewards.rewardToPool;
@@ -515,7 +521,8 @@ function generateTransactionOutputs(rpcData, poolAddress) {
 
 module.exports.RtmBlockTemplate = function(rpcData, poolAddress) {
   const extraNoncePlaceholderLength = 17;
-  const coinbaseVersion = rpcData.coinbasedevreward ? Buffer.concat([packUInt16LE(1), packUInt16LE(0)]) : Buffer.concat([packUInt16LE(3), packUInt16LE(5)]);
+  const hasDevReward = hasValidCoinbaseDevReward(rpcData);
+  const coinbaseVersion = hasDevReward ? Buffer.concat([packUInt16LE(1), packUInt16LE(0)]) : Buffer.concat([packUInt16LE(3), packUInt16LE(5)]);
 
   const scriptSigPart1 = Buffer.concat([
     serializeNumber(rpcData.height),
@@ -544,7 +551,7 @@ module.exports.RtmBlockTemplate = function(rpcData, poolAddress) {
     packUInt32LE(0), // txInSequence
     // end transaction input
     // transaction output
-    generateTransactionOutputs(rpcData, poolAddress, is_witness),
+    generateTransactionOutputs(rpcData, poolAddress, hasDevReward),
     // end transaction ouput
     packUInt32LE(0) // txLockTime
   ]);

--- a/tests/test.js
+++ b/tests/test.js
@@ -179,6 +179,12 @@ function buildRtmTemplate(transactions, overrides = {}) {
   }, overrides), "RUCyaEZxQu3Eure73XPQ57si813RYAMQKC");
 }
 
+test("RtmBlockTemplate rejects invalid RTM coinbase dev rewards", () => {
+  assert.throws(() => buildRtmTemplate([], {
+    coinbasedevreward: { value: 100000000, scriptpubkey: "zz" }
+  }), /Invalid coinbase dev reward/);
+});
+
 test("readTransaction handles RTM quorum commitment payload boundaries", () => {
   const txBuffer = Buffer.from(rtmQuorumCommitmentTxHex, "hex");
   const parsed = rtm.readTransaction(txBuffer, 0, true);


### PR DESCRIPTION
### Motivation

- Fix a fail-open validation path where malformed `rpcData.coinbasedevreward` could be skipped as an output but its `value` would still inflate the pool payout and change the coinbase transaction version.
- Ensure daemon-supplied dev-reward data is treated as trusted-only after explicit validation so miners are not given invalid block templates that waste work.

### Description

- Add `hasValidCoinbaseDevReward(rpcData)` which uses `validateCoinbaseDevReward()` and throws on malformed dev-reward objects instead of silently returning false.
- Change `generateTransactionOutputs()` to accept a `hasDevReward` flag and only add `coinbasedevreward.value` into reward accounting when the dev reward has been validated.
- Use the validated `hasDevReward` state for coinbase transaction version selection so the version matches the actual emitted outputs.
- Add a regression test in `tests/test.js` asserting that a malformed `coinbasedevreward.scriptpubkey` causes `RtmBlockTemplate()` to throw (`Invalid coinbase dev reward`).

### Testing

- Ran a targeted RTM validation smoke test with dependency stubs (simulating absent, valid, and malformed `coinbasedevreward`) and the stubbed tests passed (valid/absent succeed, malformed throws as expected).
- Ran `git diff --check` to ensure no whitespace/patch issues and it passed.
- Attempted `npm test` but it was blocked by the environment/registry returning `403 Forbidden` while fetching dependencies so full test suite could not be executed.
- Attempted `node --test --test-reporter=spec tests/test.js` but it failed in this environment due to the missing native addon build artifact (`../build/Release/blocktemplate`), so the full test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a207307cc7c8321a7a41f6701593263)