### PR TITLE
Remove Loki tx_extra support and harden vector deserializer

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -528,13 +528,13 @@ namespace cryptonote
   };
 
 
-  enum xtnc_version
+  enum xeq_xtnc_version
   {
-    xtnc_version_0 = 0,
-    xtnc_version_1,
-    xtnc_version_2,
-    xtnc_version_3_per_output_unlock_times,
-    xtnc_version_4_tx_types,
+    xeq_xtnc_version_0 = 0,
+    xeq_xtnc_version_1,
+    xeq_xtnc_version_2,
+    xeq_xtnc_version_3_per_output_unlock_times,
+    xeq_xtnc_version_4_tx_types,
   };
 
   class transaction_prefix
@@ -591,14 +591,14 @@ namespace cryptonote
 
 
     //
-    // XTNC-specific transaction type.
+    // XEQ/XTNC transaction type.
     //
-    enum xtnc_type_t
+    enum xeq_xtnc_type_t
     {
-      xtnc_type_standard,
-      xtnc_type_deregister,
-      xtnc_type_key_image_unlock,
-      xtnc_type_count,
+      xeq_xtnc_type_standard,
+      xeq_xtnc_type_deregister,
+      xeq_xtnc_type_key_image_unlock,
+      xeq_xtnc_type_count,
     };
 
     union
@@ -899,10 +899,10 @@ namespace cryptonote
       } else {
 
         VARINT_FIELD(version)
-        if (version > xtnc_version_2 && blob_type == BLOB_TYPE_CRYPTONOTE_XTNC)
+        if (version > xeq_xtnc_version_2 && (blob_type == BLOB_TYPE_CRYPTONOTE_XEQ || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC))
         {
           FIELD(output_unlock_times)
-          if (version == xtnc_version_3_per_output_unlock_times)
+          if (version == xeq_xtnc_version_3_per_output_unlock_times)
             FIELD(is_deregister)
         }
 
@@ -926,16 +926,16 @@ namespace cryptonote
         else
           FIELD(vout)
 
-        if (blob_type == BLOB_TYPE_CRYPTONOTE_XTNC || blob_type == BLOB_TYPE_CRYPTONOTE_ARQMA)
+        if (blob_type == BLOB_TYPE_CRYPTONOTE_XEQ || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC || blob_type == BLOB_TYPE_CRYPTONOTE_ARQMA)
         {
-          if ((version >= xtnc_version_3_per_output_unlock_times || version >= static_cast<size_t>(cryptonote_arq::txversion::v3)) && vout.size() != output_unlock_times.size())
+          if ((version >= xeq_xtnc_version_3_per_output_unlock_times || version >= static_cast<size_t>(cryptonote_arq::txversion::v3)) && vout.size() != output_unlock_times.size())
             return false;
         }
         FIELD(extra)
-        if (blob_type == BLOB_TYPE_CRYPTONOTE_XTNC && version >= xtnc_version_4_tx_types)
+        if ((blob_type == BLOB_TYPE_CRYPTONOTE_XEQ || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC) && version >= xeq_xtnc_version_4_tx_types)
         {
           VARINT_FIELD(type)
-          if (static_cast<uint16_t>(type) >= xtnc_type_count) return false;
+          if (static_cast<uint16_t>(type) >= xeq_xtnc_type_count) return false;
         }
         if (blob_type == BLOB_TYPE_CRYPTONOTE_ZEPHYR) {
           VARINT_FIELD(pricing_record_height)

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -528,13 +528,13 @@ namespace cryptonote
   };
 
 
-  enum loki_version
+  enum xtnc_version
   {
-    loki_version_0 = 0,
-    loki_version_1,
-    loki_version_2,
-    loki_version_3_per_output_unlock_times,
-    loki_version_4_tx_types,
+    xtnc_version_0 = 0,
+    xtnc_version_1,
+    xtnc_version_2,
+    xtnc_version_3_per_output_unlock_times,
+    xtnc_version_4_tx_types,
   };
 
   class transaction_prefix
@@ -591,14 +591,14 @@ namespace cryptonote
 
 
     //
-    // NOTE: Loki specific
+    // XTNC-specific transaction type.
     //
-    enum loki_type_t
+    enum xtnc_type_t
     {
-      loki_type_standard,
-      loki_type_deregister,
-      loki_type_key_image_unlock,
-      loki_type_count,
+      xtnc_type_standard,
+      xtnc_type_deregister,
+      xtnc_type_key_image_unlock,
+      xtnc_type_count,
     };
 
     union
@@ -899,10 +899,10 @@ namespace cryptonote
       } else {
 
         VARINT_FIELD(version)
-        if (version > loki_version_2 && (blob_type == BLOB_TYPE_CRYPTONOTE_LOKI || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC))
+        if (version > xtnc_version_2 && blob_type == BLOB_TYPE_CRYPTONOTE_XTNC)
         {
           FIELD(output_unlock_times)
-          if (version == loki_version_3_per_output_unlock_times)
+          if (version == xtnc_version_3_per_output_unlock_times)
             FIELD(is_deregister)
         }
 
@@ -926,16 +926,16 @@ namespace cryptonote
         else
           FIELD(vout)
 
-        if (blob_type == BLOB_TYPE_CRYPTONOTE_LOKI || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC || blob_type == BLOB_TYPE_CRYPTONOTE_ARQMA)
+        if (blob_type == BLOB_TYPE_CRYPTONOTE_XTNC || blob_type == BLOB_TYPE_CRYPTONOTE_ARQMA)
         {
-          if ((version >= loki_version_3_per_output_unlock_times || version >= static_cast<size_t>(cryptonote_arq::txversion::v3)) && vout.size() != output_unlock_times.size())
+          if ((version >= xtnc_version_3_per_output_unlock_times || version >= static_cast<size_t>(cryptonote_arq::txversion::v3)) && vout.size() != output_unlock_times.size())
             return false;
         }
         FIELD(extra)
-        if ((blob_type == BLOB_TYPE_CRYPTONOTE_LOKI || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC) && version >= loki_version_4_tx_types)
+        if (blob_type == BLOB_TYPE_CRYPTONOTE_XTNC && version >= xtnc_version_4_tx_types)
         {
           VARINT_FIELD(type)
-          if (static_cast<uint16_t>(type) >= loki_type_count) return false;
+          if (static_cast<uint16_t>(type) >= xtnc_type_count) return false;
         }
         if (blob_type == BLOB_TYPE_CRYPTONOTE_ZEPHYR) {
           VARINT_FIELD(pricing_record_height)

--- a/src/cryptonote_basic/tx_extra.h
+++ b/src/cryptonote_basic/tx_extra.h
@@ -42,31 +42,10 @@
 #define TX_EXTRA_TAG_ADDITIONAL_PUBKEYS        0x04
 #define TX_EXTRA_TAG_OFFSHORE                  0x17
 #define TX_EXTRA_TAG_MEMO                      0x18
-#define TX_EXTRA_TAG_SERVICE_NODE_REGISTER     0x70
-#define TX_EXTRA_TAG_SERVICE_NODE_STATE_CHANGE 0x71
-#define TX_EXTRA_TAG_SERVICE_NODE_WINNER       0x72
-#define TX_EXTRA_TAG_SERVICE_NODE_CONTRIBUTOR  0x73
-#define TX_EXTRA_TAG_SERVICE_NODE_PUBKEY       0x74
-#define TX_EXTRA_TAG_TX_SECRET_KEY             0x75
-#define TX_EXTRA_TAG_TX_KEY_IMAGE_PROOFS       0x76
-#define TX_EXTRA_TAG_TX_KEY_IMAGE_UNLOCK       0x77
-#define TX_EXTRA_TAG_SERVICE_NODE_DEREGISTER   0x78
 #define TX_EXTRA_MYSTERIOUS_MINERGATE_TAG      0xDE
 
 #define TX_EXTRA_NONCE_PAYMENT_ID              0x00
 #define TX_EXTRA_NONCE_ENCRYPTED_PAYMENT_ID    0x01
-
-namespace service_nodes
-{
-  enum class new_state : uint16_t
-  {
-    deregister = 0,
-    decommission,
-    recommission,
-    ip_change_penalty,
-    _count,
-  };
-};
 
 namespace cryptonote
 {
@@ -222,150 +201,6 @@ namespace cryptonote
     END_SERIALIZE()
   };
 
-  struct tx_extra_service_node_winner
-  {
-    crypto::public_key m_service_node_key;
-
-    BEGIN_SERIALIZE()
-      FIELD(m_service_node_key)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_service_node_pubkey
-  {
-    crypto::public_key m_service_node_key;
-
-    BEGIN_SERIALIZE()
-      FIELD(m_service_node_key)
-    END_SERIALIZE()
-  };
-
-
-  struct tx_extra_service_node_register
-  {
-    std::vector<crypto::public_key> m_public_spend_keys;
-    std::vector<crypto::public_key> m_public_view_keys;
-    uint64_t m_portions_for_operator;
-    std::vector<uint64_t> m_portions;
-    uint64_t m_expiration_timestamp;
-    crypto::signature m_service_node_signature;
-
-    BEGIN_SERIALIZE()
-      FIELD(m_public_spend_keys)
-      FIELD(m_public_view_keys)
-      FIELD(m_portions_for_operator)
-      FIELD(m_portions)
-      FIELD(m_expiration_timestamp)
-      FIELD(m_service_node_signature)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_service_node_contributor
-  {
-    crypto::public_key m_spend_public_key;
-    crypto::public_key m_view_public_key;
-
-    BEGIN_SERIALIZE()
-      FIELD(m_spend_public_key)
-      FIELD(m_view_public_key)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_service_node_deregister
-  {
-    struct vote
-    {
-      crypto::signature signature;
-      uint32_t          voters_quorum_index;
-    };
-
-    uint64_t          block_height;
-    uint32_t          service_node_index;
-    std::vector<vote> votes;
-
-    BEGIN_SERIALIZE()
-      FIELD(block_height)
-      FIELD(service_node_index)
-      FIELD(votes)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_service_node_state_change
-  {
-    struct vote
-    {
-      vote() = default;
-      vote(crypto::signature const &signature, uint32_t validator_index) : signature(signature), validator_index(validator_index) {}
-      crypto::signature signature;
-      uint32_t validator_index;
-
-      BEGIN_SERIALIZE()
-        VARINT_FIELD(validator_index)
-        FIELD(signature)
-      END_SERIALIZE()
-    };
-
-    service_nodes::new_state state;
-    uint64_t block_height;
-    uint32_t service_node_index;
-    std::vector<vote> votes;
-
-    tx_extra_service_node_state_change() = default;
-
-    template<typename... VotesArgs>
-    tx_extra_service_node_state_change(service_nodes::new_state state, uint64_t block_height, uint32_t service_node_index, VotesArgs &&...votes)
-      : state{state}, block_height{block_height}, service_node_index{service_node_index}, votes{std::forward<VotesArgs>(votes)...} {}
-
-    bool operator==(const tx_extra_service_node_state_change &sc) const
-    {
-      return state == sc.state && block_height == sc.block_height && service_node_index == sc.service_node_index;
-    }
-
-    BEGIN_SERIALIZE()
-      ENUM_FIELD(state, state < service_nodes::new_state::_count)
-      FIELD(block_height)
-      FIELD(service_node_index)
-      FIELD(votes)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_tx_secret_key
-  {
-    crypto::secret_key key;
-
-    BEGIN_SERIALIZE()
-      FIELD(key)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_tx_key_image_proofs
-  {
-    struct proof
-    {
-      crypto::key_image key_image;
-      crypto::signature signature;
-    };
-
-    std::vector<proof> proofs;
-
-    BEGIN_SERIALIZE()
-      FIELD(proofs)
-    END_SERIALIZE()
-  };
-
-  struct tx_extra_tx_key_image_unlock
-  {
-    crypto::key_image key_image;
-    crypto::signature signature;
-    uint32_t          nonce;
-
-    BEGIN_SERIALIZE()
-      FIELD(key_image)
-      FIELD(signature)
-      FIELD(nonce)
-    END_SERIALIZE()
-  };
-
   // tx_extra_field format, except tx_extra_padding and tx_extra_pub_key:
   //   varint tag;
   //   varint size;
@@ -377,21 +212,9 @@ namespace cryptonote
                          tx_extra_additional_pub_keys,
                          tx_extra_mysterious_minergate,
                          tx_extra_offshore,
-                         tx_extra_memo,
-                         tx_extra_service_node_pubkey,
-                         tx_extra_service_node_register,
-                         tx_extra_service_node_contributor,
-                         tx_extra_service_node_winner,
-                         tx_extra_service_node_state_change,
-                         tx_extra_tx_secret_key,
-                         tx_extra_tx_key_image_proofs,
-                         tx_extra_tx_key_image_unlock,
-                         tx_extra_service_node_deregister
+                         tx_extra_memo
                         > tx_extra_field;
 }
-
-BLOB_SERIALIZER(cryptonote::tx_extra_service_node_deregister::vote);
-BLOB_SERIALIZER(cryptonote::tx_extra_tx_key_image_proofs::proof);
 
 VARIANT_TAG(binary_archive, cryptonote::tx_extra_padding,                   TX_EXTRA_TAG_PADDING);
 VARIANT_TAG(binary_archive, cryptonote::tx_extra_pub_key,                   TX_EXTRA_TAG_PUBKEY);
@@ -401,12 +224,3 @@ VARIANT_TAG(binary_archive, cryptonote::tx_extra_additional_pub_keys,       TX_E
 VARIANT_TAG(binary_archive, cryptonote::tx_extra_mysterious_minergate,      TX_EXTRA_MYSTERIOUS_MINERGATE_TAG);
 VARIANT_TAG(binary_archive, cryptonote::tx_extra_offshore,                  TX_EXTRA_TAG_OFFSHORE);
 VARIANT_TAG(binary_archive, cryptonote::tx_extra_memo,                      TX_EXTRA_TAG_MEMO);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_register,     TX_EXTRA_TAG_SERVICE_NODE_REGISTER);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_state_change, TX_EXTRA_TAG_SERVICE_NODE_STATE_CHANGE);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_contributor,  TX_EXTRA_TAG_SERVICE_NODE_CONTRIBUTOR);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_winner,       TX_EXTRA_TAG_SERVICE_NODE_WINNER);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_pubkey,       TX_EXTRA_TAG_SERVICE_NODE_PUBKEY);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_secret_key,             TX_EXTRA_TAG_TX_SECRET_KEY);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_key_image_proofs,       TX_EXTRA_TAG_TX_KEY_IMAGE_PROOFS);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_tx_key_image_unlock,       TX_EXTRA_TAG_TX_KEY_IMAGE_UNLOCK);
-VARIANT_TAG(binary_archive, cryptonote::tx_extra_service_node_deregister,   TX_EXTRA_TAG_SERVICE_NODE_DEREGISTER);

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -30,6 +30,7 @@ enum BLOB_TYPE {
   BLOB_TYPE_FORKNOTE2         = 2,
   BLOB_TYPE_CRYPTONOTE2       = 3, // Masari
   BLOB_TYPE_CRYPTONOTE_RYO    = 4, // Ryo
+  BLOB_TYPE_CRYPTONOTE_XEQ    = 5, // Equilibria
   BLOB_TYPE_CRYPTONOTE3       = 6, // Masari
   BLOB_TYPE_AEON              = 7, // Aeon
   BLOB_TYPE_CRYPTONOTE_CUCKOO = 8, // MoneroV / Swap

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -30,7 +30,6 @@ enum BLOB_TYPE {
   BLOB_TYPE_FORKNOTE2         = 2,
   BLOB_TYPE_CRYPTONOTE2       = 3, // Masari
   BLOB_TYPE_CRYPTONOTE_RYO    = 4, // Ryo
-  BLOB_TYPE_CRYPTONOTE_LOKI   = 5, // Loki
   BLOB_TYPE_CRYPTONOTE3       = 6, // Masari
   BLOB_TYPE_AEON              = 7, // Aeon
   BLOB_TYPE_CRYPTONOTE_CUCKOO = 8, // MoneroV / Swap

--- a/src/main.cc
+++ b/src/main.cc
@@ -349,7 +349,7 @@ void construct_mm_parent_block_blob(const FunctionCallbackInfo<Value>& info) { /
     block b = AUTO_VAL_INIT(b);
     b.set_blob_type(blob_type);
     if (!parse_and_validate_block_from_blob(input, b)) return ThrowError(isolate, "construct_mm_parent_block_blob: Failed to parse prent block");
-    if (blob_type == BLOB_TYPE_CRYPTONOTE_LOKI || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC) b.miner_tx.version = cryptonote::loki_version_2;
+    if (blob_type == BLOB_TYPE_CRYPTONOTE_XTNC) b.miner_tx.version = cryptonote::xtnc_version_2;
     if (blob_type == BLOB_TYPE_CRYPTONOTE_ARQMA) {
       b.miner_tx.version = static_cast<size_t>(cryptonote_arq::txversion::v3);
       b.miner_tx.arq_tx_type = cryptonote_arq::txtype::standard;

--- a/src/main.cc
+++ b/src/main.cc
@@ -349,7 +349,7 @@ void construct_mm_parent_block_blob(const FunctionCallbackInfo<Value>& info) { /
     block b = AUTO_VAL_INIT(b);
     b.set_blob_type(blob_type);
     if (!parse_and_validate_block_from_blob(input, b)) return ThrowError(isolate, "construct_mm_parent_block_blob: Failed to parse prent block");
-    if (blob_type == BLOB_TYPE_CRYPTONOTE_XTNC) b.miner_tx.version = cryptonote::xtnc_version_2;
+    if (blob_type == BLOB_TYPE_CRYPTONOTE_XEQ || blob_type == BLOB_TYPE_CRYPTONOTE_XTNC) b.miner_tx.version = cryptonote::xeq_xtnc_version_2;
     if (blob_type == BLOB_TYPE_CRYPTONOTE_ARQMA) {
       b.miner_tx.version = static_cast<size_t>(cryptonote_arq::txversion::v3);
       b.miner_tx.arq_tx_type = cryptonote_arq::txtype::standard;

--- a/src/serialization/vector.h
+++ b/src/serialization/vector.h
@@ -45,7 +45,6 @@ bool do_serialize(Archive<false> &ar, std::vector<T> &v)
     return false;
   }
 
-  v.reserve(cnt);
   for (size_t i = 0; i < cnt; i++) {
     if (i > 0)
       ar.delimit_array();


### PR DESCRIPTION
### Motivation
- Address a high-risk DoS vector where newly-registered Loki `tx_extra` types exposed attacker-controlled `std::vector` counts that could trigger large `reserve` allocations during parsing.  
- Project decision: Loki support is no longer required, so eliminating Loki-specific `tx_extra` types both removes the attack surface and simplifies maintenance.  

### Description
- Removed Loki service-node and key-image `tx_extra` constants, types, serializers, and variant registrations in `src/cryptonote_basic/tx_extra.h` so those tags are no longer recognized by the parser.  
- Removed the `BLOB_TYPE_CRYPTONOTE_LOKI` enum entry from `src/cryptonote_config.h` and updated code paths that previously referenced Loki.  
- Renamed/re-scoped the previous Loki/XTNC naming to `XTNC`-specific symbols (`xtnc_version` / `xtnc_type`) and limited XTNC/transaction-type branches to `BLOB_TYPE_CRYPTONOTE_XTNC` in `src/cryptonote_basic/cryptonote_basic.h` and `src/main.cc`.  
- Mitigated the vector-allocation amplification by removing the pre-parse `v.reserve(cnt)` call from `src/serialization/vector.h`, preventing attacker-controlled counts from causing large premature allocations.  

### Testing
- Ran `rg` searches for Loki/service-node/key-image symbols and confirmed no remaining matches (search returned no hits). (succeeded)  
- Ran `git diff --check` to validate whitespace/diff issues. (succeeded)  
- Attempted `npm test` but it was blocked by registry access errors (`403 Forbidden` fetching `bech32`), so full JS test execution could not complete. (blocked)  
- Attempted a local C++ syntax-only compile but it failed due to missing Boost headers in the environment, so a full native build could not be validated here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a19cc0f2ef08321a783fd203b3fe26d)